### PR TITLE
Delete dependency graph job on build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,3 @@ jobs:
         run: mvn -B package --file pom.xml
       - name: Run unit tests
         run: mvn test
-
-      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-      - name: Update dependency graph
-        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
Delete the dependency graph job on build CI because it is useless right now and causes problems with PRs.